### PR TITLE
Improve loading

### DIFF
--- a/required/euler_navp.yolol
+++ b/required/euler_navp.yolol
@@ -1,23 +1,23 @@
 o=90 p=180 u=40 v=50 d=10 h=0.5 ds="$" ns="" nd=0 t="9843" r=17 GOTO3
 :nPit=u*n3^3+v*n3 :nHdg=(1-2*(n1>0))*(-u*j^3-v*j+o) :nDist=nd
 s0=:sy%4 x=1*nd n1=:nX-:x n2=:nZ-:z n3=:nY-:y nd=SQRT(n1^2+n2^2+n3^2)
-:nStat="" m=0 n=-1 i=3 x=1*nd n1/=nd n2/=nd n3/=nd nd=nd/1000*1000
-j=n2/SQRT(1.001-n3^2) x=:sy%4 GOTO5-(3-12*(ns!=:nStr))*(x!=s0)
+n=-1 :nStat="" x=1*nd n1/=nd n2/=nd n3/=nd nd=nd/1000*1000//euler_navp
+m=0 j=n2/SQRT(1.001-n3^2) x=:sy%4 GOTO5-(3-12*(ns!=:nStr))*(x!=s0)
 s0=:sy err+=2*(err<9)*(:sy>"9") x=6-(err--<1) GOTOx+(14-x)*(ns!=:nStr)
 s-- s*=s>0 p1="X+:\nPrograde0" p2="X-:\nRetrograde1" p3="Y+:\nNormal3" 
 s*=s<7 p4="Y-:\nAnti-normal4" p5="Z+:\nRadial5" p6="Z-:\nAnti-radial6"
 :nName="Preset "+p1+p2+p3+p4+p5+p6-s-p1-p2-p3-p4-p5-p6 GOTO10+s/2
-sn=1-2*(s%2) n1=sn n2=0 n3=0 nd="-" :nX=sn :nY=0 :nZ=0 GOTO3 // euler
-sn=1-2*(s%2) n1=0 n2=0 n3=sn nd="-" :nX=0 :nY=sn :nZ=0 GOTO3 // navp
-sn=1-2*(s%2) n1=0 n2=sn n3=0 nd="-" :nX=0 :nY=0 :nZ=sn GOTO3
+sn=1-2*(s%2) n1=sn n2=0 n3=0 nd="-" :nX=sn :nY=0 :nZ=0 GOTO3     // by
+sn=1-2*(s%2) n1=0 n2=0 n3=sn nd="-" :nX=0 :nY=sn :nZ=0 GOTO3  // Stand
+sn=1-2*(s%2) n1=0 n2=sn n3=0 nd="-" :nX=0 :nY=0 :nZ=sn GOTO3  // Peter
 x=1 x/=ns==:nStr IF :nStat=="" THEN :nStat=ss :nName=nn END GOTO13
-:nStat="[ Loading ]" nn="" l="/" ns=:nStr s=ns x=1 x/=ns GOTO7
+:nStat="[ Loading ]" i=3 nn="" l="/" ns=:nStr s=ns x=1 x/=ns GOTO7
 x/=ns=="" ss="NO WAYPOINT" :nStat=ss nn="    NaN" :nName=nn GOTO13
-:nName=nn c=s c-=--s x/=c!=ds nn=c+nn GOTO16+4*(s=="")-p*(ns!=:nStr)
+:nName=nn c=s c-=--s x/=c!=ds nn=c+nn GOTO(2+4*(s==""))*(ns==:nStr)+14
 c=s c-=--s x/=c>l w=5*(c>4)+2*(t>(t-c)) w+=w<c w+=w<c m+=w*d^n++ GOTOr
 IF c=="-" THEN m*=-1 s-- END x/=s>"" i-- :nX=m x/=i :nY=m x/=i-1 :nZ=m
-x/=s>"" m=0 n=-1 x=1 nd=1 GOTO17-15*(i<1)-p*(ns!=:nStr)//by StandPeter
-ss="[  ERROR  ]" :nStat=ss nn="Bad Format" :nName=nn GOTO13  //NavGrid
+x/=s>"" m=0 n=-1 x=1 nd=1 GOTO(3-14*(i<1))*(ns==:nStr)+14       // for
+ss="[  ERROR  ]" :nStat=ss nn="Bad Format" :nName=nn GOTO13 // NavGrid
 // ------------------ This line is 70 chars long ------------------- >
 
 // euler_navp.yolol

--- a/required/euler_navp.yolol
+++ b/required/euler_navp.yolol
@@ -1,22 +1,22 @@
 o=90 p=180 u=40 v=50 d=10 h=0.5 ds="$" ns="" nd=0 t="9843" r=17 GOTO3
-:nPit=u*n3^3+v*n3 :nHdg=(1-2*(n1>0))*(-u*i^3-v*i+o) :nDist=nd
+:nPit=u*n3^3+v*n3 :nHdg=(1-2*(n1>0))*(-u*j^3-v*j+o) :nDist=nd
 s0=:sy%4 x=1*nd n1=:nX-:x n2=:nZ-:z n3=:nY-:y nd=SQRT(n1^2+n2^2+n3^2)
-:nStat="" x=1*nd n1/=nd n2/=nd n3/=nd nd=nd/1000*1000  //euler_navp by
-i=n2/SQRT(1-n3^2) x=:sy%4 GOTO5-(3-12*(ns!=:nStr))*(x!=s0)//StandPeter
+:nStat="" m=0 n=-1 i=3 x=1*nd n1/=nd n2/=nd n3/=nd nd=nd/1000*1000
+j=n2/SQRT(1.001-n3^2) x=:sy%4 GOTO5-(3-12*(ns!=:nStr))*(x!=s0)
 s0=:sy err+=2*(err<9)*(:sy>"9") x=6-(err--<1) GOTOx+(14-x)*(ns!=:nStr)
-s-- s*=s>0 p1="X+:\nPrograde0" p2="X-:\nRetrograde1" p3="Z+:\nRadial2"
-s*=s<7 p4="Z-:\nAnti-radial3" p5="Y+:\nNormal4" p6="Y-:\nAnti-normal5"
+s-- s*=s>0 p1="X+:\nPrograde0" p2="X-:\nRetrograde1" p3="Y+:\nNormal3" 
+s*=s<7 p4="Y-:\nAnti-normal4" p5="Z+:\nRadial5" p6="Z-:\nAnti-radial6"
 :nName="Preset "+p1+p2+p3+p4+p5+p6-s-p1-p2-p3-p4-p5-p6 GOTO10+s/2
-sn=1-2*(s%2) n1=.99*sn n2=0 n3=0 nd="-" :nX=sn :nY=0 :nZ=0 GOTO3
-sn=1-2*(s%2) n1=0 n2=.99*sn n3=0 nd="-" :nX=0 :nY=0 :nZ=sn GOTO3
-sn=1-2*(s%2) n1=0 n2=0 n3=.99*sn nd="-" :nX=0 :nY=sn :nZ=0 GOTO3
+sn=1-2*(s%2) n1=sn n2=0 n3=0 nd="-" :nX=sn :nY=0 :nZ=0 GOTO3 // euler
+sn=1-2*(s%2) n1=0 n2=0 n3=sn nd="-" :nX=0 :nY=sn :nZ=0 GOTO3 // navp
+sn=1-2*(s%2) n1=0 n2=sn n3=0 nd="-" :nX=0 :nY=0 :nZ=sn GOTO3
 x=1 x/=ns==:nStr IF :nStat=="" THEN :nStat=ss :nName=nn END GOTO13
 :nStat="[ Loading ]" nn="" l="/" ns=:nStr s=ns x=1 x/=ns GOTO7
 x/=ns=="" ss="NO WAYPOINT" :nStat=ss nn="    NaN" :nName=nn GOTO13
-m=0 n=-1 i=3 :nName=nn c=s c-=--s x/=c!=ds nn=c+nn GOTO16+4*(s=="")
+:nName=nn c=s c-=--s x/=c!=ds nn=c+nn GOTO16+4*(s=="")-p*(ns!=:nStr)
 c=s c-=--s x/=c>l w=5*(c>4)+2*(t>(t-c)) w+=w<c w+=w<c m+=w*d^n++ GOTOr
-IF c=="-" THEN m*=-1 s-- END x/=s>"" i-- nx=m x/=i ny=m x/=i-1 nz=m
-x/=s>"" m=0 n=-1 x=1 nd=1 :nX=nx :nY=ny :nZ=nz GOTO17-15*(i<1)   //for
+IF c=="-" THEN m*=-1 s-- END x/=s>"" i-- :nX=m x/=i :nY=m x/=i-1 :nZ=m
+x/=s>"" m=0 n=-1 x=1 nd=1 GOTO17-15*(i<1)-p*(ns!=:nStr)//by StandPeter
 ss="[  ERROR  ]" :nStat=ss nn="Bad Format" :nName=nn GOTO13  //NavGrid
 // ------------------ This line is 70 chars long ------------------- >
 

--- a/required/navp.yolol
+++ b/required/navp.yolol
@@ -4,16 +4,16 @@ x=1 di=:nUp-:nDn st=1-:nSet :nSet=0 sv=1-:nSave :nSave=0 :nUp=0 :nDn=0
 x/=sv*st+(i<7) i+=di i+=1*(i<1)-1*(i>20) is="0"-(i<10)+i GOTO2-(di!=0)
 t=9 H=1000 ds="$" np="%np" om=n+"OVERWRITING\nConfirm? " x/=sv GOTO9
 x/=(:nStr!="")*(1-:nSave) :nSave=0 :NavP=is+r+om+t GOTO6-4*(t--<1)
-nn=:nName nn=nn-ds-np x/=nn!=:nName :nName=nn GOTO7      //NavP.yolol
-v=np+is+": "+:nX/H*H+" "+:nY/H*H+" "+:nZ/H*H+ds+nn GOTO11//for NavGrid
+nn=:nName nn=nn-ds-np x/=nn!=:nName :nName=nn GOTO7      // NavP.yolol
+:nName=nn :nX=:nX/H*H :nY=:nY/H*H :nZ=:nZ/H*H GOTO11    // for NavGrid
 x/=(:nStr!="")*(1-:nSet) :nSet=0 :NavP=is+r+om+t GOTO9-7*(t--<1)
-nn="Navpoint "+is v=np+is+": "+:x/H*H+" "+:y/H*H+" "+:z/H*H+ds+nn
-:nName=nn :NavP=is+r+"[ Saving  ]"+n+nn                //by StandPeter
-IF i==7 THEN:np07=v ENDIF i==8 THEN:np08=v ENDIF i==9 THEN:np09=v END
-IFi==10 THEN:np10=v ENDIFi==11 THEN:np11=v ENDIFi==12 THEN:np12=v END
-IFi==13 THEN:np13=v ENDIFi==14 THEN:np14=v ENDIFi==15 THEN:np15=v END
-IFi==16 THEN:np16=v ENDIFi==17 THEN:np17=v ENDIFi==18 THEN:np18=v END
-IFi==19 THEN:np19=v ENDIFi==20 THEN:np20=v END :nSet=0 :nSave=0 GOTO2
+:nName="Navpoint "+is :nX=:x/H*H :nY=:y/H*H :nZ=:z/H*H //by StandPeter
+:NavP=is+r+"[ Saving  ]"+n+nn u=np+is+": "+:nX+" "+:nY+" "+:nZ+ds+nn
+IF i==7 THEN:np07=u ENDIF i==8 THEN:np08=u ENDIF i==9 THEN:np09=u END
+IFi==10 THEN:np10=u ENDIFi==11 THEN:np11=u ENDIFi==12 THEN:np12=u END
+IFi==13 THEN:np13=u ENDIFi==14 THEN:np14=u ENDIFi==15 THEN:np15=u END
+IFi==16 THEN:np16=u ENDIFi==17 THEN:np17=u ENDIFi==18 THEN:np18=u END
+IFi==19 THEN:np19=u ENDIFi==20 THEN:np20=u END :nSet=0 :nSave=0 GOTO2
 a=:np07 b=:np08 c=:np09 d=:np10 e=:np11 v=a+b+c+d+e-w-a-b-c-d-e GOTO2
 a=:np12 b=:np13 c=:np14 d=:np15 v=a+b+c+d-w-a-b-c-d GOTO2
 a=:np16 b=:np17 c=:np18 d=:np19 e=:np20 v=a+b+c+d+e-w-a-b-c-d-e GOTO2

--- a/required/navp.yolol
+++ b/required/navp.yolol
@@ -1,5 +1,5 @@
-i+=i<1 v=i :nStat="" :nName="" idx=i-7/(i>6) w=np+is GOTO17+idx/5
-n="\n\n" r="/20\n" :nStr=v :NavP=is+r+:nStat+n+:nName
+i+=i<1 v0=v v=i :nName="" idx=i-7/(i>6) v=v0 w=np+is GOTO17+idx/5
+n="\n\n" r="/20\n" :nStr=v :nStat-="0" :NavP=is+r+:nStat+n+:nName
 x=1 di=:nUp-:nDn st=1-:nSet :nSet=0 sv=1-:nSave :nSave=0 :nUp=0 :nDn=0
 x/=sv*st+(i<7) i+=di i+=1*(i<1)-1*(i>20) is="0"-(i<10)+i GOTO2-(di!=0)
 t=9 H=1000 ds="$" np="%np" om=n+"OVERWRITING\nConfirm? " x/=sv GOTO9
@@ -17,7 +17,7 @@ IFi==19 THEN:np19=u ENDIFi==20 THEN:np20=u END :nSet=0 :nSave=0 GOTO2
 a=:np07 b=:np08 c=:np09 d=:np10 e=:np11 v=a+b+c+d+e-w-a-b-c-d-e GOTO2
 a=:np12 b=:np13 c=:np14 d=:np15 v=a+b+c+d-w-a-b-c-d GOTO2
 a=:np16 b=:np17 c=:np18 d=:np19 e=:np20 v=a+b+c+d+e-w-a-b-c-d-e GOTO2
-:nStat="[  ERROR  ]" :nName=" No Memory" v="" GOTO2 //starbase-navgrid
+:nStat="[  ERROR  ]" :nName=" No Memory" GOTO2     // starbase-navgrid
 // ------------------ This line is 70 chars long ------------------- >
 
 // navp.yolol


### PR DESCRIPTION
- When setting or saving, load new navpoint coordinates directly into nX/nY/nZ instead of re-parsing
- Allow parsing to be interrupted when scrolling through indexes
- Rearrange preset indexes - I had thought putting "y" last would be most useful, but feedback shows "z" is more popular

closes #10, closes #11